### PR TITLE
fix npm install warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "author": {
     "name": "İsmail Demirbilek"
   },
+  "repository": "https://github.com/dbtek/bootstrap-vertical-tabs.git",
   "dependencies": {},
   "devDependencies": {
     "grunt": "~0.4.2",


### PR DESCRIPTION
fix "npm WARN package.json bootstrap-vertical-tabs@1.2.1 No repository field."