### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Vertical tabs component for Bootstrap 3.
   </ul>
 </div>
 ```
-####Sideways Tabs :new:
+#### Sideways Tabs :new:
 
 Add `sideways` class to tabs.
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
